### PR TITLE
Move code to src

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Bibliography = "f1be7e48-bf82-45af-a471-ae754a193061"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,9 @@
 using Documenter
+using DocumenterCitations
+import DocumenterCitations
 using Bibliography
 
-const BIBLIOGRAPHY = import_bibtex("test.bib")
-
-include("bibliography.jl")
-include("citations.jl")
+DocumenterCitations.BIBLIOGRAPHY() = import_bibtex(joinpath(@__DIR__, "test.bib"))
 
 makedocs(
     sitename = "Testing BibTeX citations and references",

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -1,0 +1,8 @@
+module DocumenterCitations
+
+
+BIBLIOGRAPHY() = ""
+include("citations.jl")
+include("bibliography.jl")
+
+end

--- a/src/bibliography.jl
+++ b/src/bibliography.jl
@@ -14,12 +14,12 @@ Selectors.matcher(::Type{BibliographyBlock}, node, page, doc) = Expanders.iscode
 function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
     @info "Expanding bibliography."
     raw_bib = "<dl>"
-    for (id, entry) in BIBLIOGRAPHY
+    for (id, entry) in BIBLIOGRAPHY()
         @info "Expanding bibliography entry: $id."
-        
+
         # Add anchor that citations can link to from anywhere in the docs.
         Anchors.add!(doc.internal.headers, entry, entry.id, page.build)
-        
+
         entry_text = """<dt>$id</dt>
         <dd>
           <div id="$id">$(xnames(entry)) ($(xyear(entry))), <a href="$(xlink(entry))">$(xtitle(entry))</a>, $(xin(entry))</a>
@@ -27,7 +27,7 @@ function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
         raw_bib *= entry_text
     end
     raw_bib *= "\n</dl>"
-    
+
     page.mapping[x] = Documents.RawNode(:html, raw_bib)
 end
 

--- a/src/citations.jl
+++ b/src/citations.jl
@@ -1,3 +1,4 @@
+
 using Documenter
 using Documenter.Anchors
 using Documenter.Builder
@@ -39,9 +40,9 @@ function expand_citation(link::Markdown.Link, meta, page, doc)
     if length(link.text) === 1 && isa(link.text[1], String)
         citation_name = link.text[1]
         @info "Expanding citation: $citation_name."
-        
-        if haskey(BIBLIOGRAPHY, citation_name)
-            entry = BIBLIOGRAPHY[citation_name]
+
+        if haskey(BIBLIOGRAPHY(), citation_name)
+            entry = BIBLIOGRAPHY()[citation_name]
             headers = doc.internal.headers
             if Anchors.exists(headers, entry.id)
                 if Anchors.isunique(headers, entry.id)
@@ -58,7 +59,7 @@ function expand_citation(link::Markdown.Link, meta, page, doc)
             else
                 push!(doc.internal.errors, :citations)
                 @warn "reference for '$(entry.id)' could not be found in $(Utilities.locrepr(page.source))."
-            end   
+            end
         else
             error("Citation not found in bibliography: $(citation_name)")
         end
@@ -69,3 +70,4 @@ function expand_citation(link::Markdown.Link, meta, page, doc)
 end
 
 expand_citation(other, meta, page, doc) = true # Continue to `walk` through element `other`.
+


### PR DESCRIPTION
 - Moves code that was in `docs/` into `src/`
 - Replaces global `BIBLIOGRAPHY` with `DocumenterCitations.BIBLIOGRAPHY()` method, which is imported/overloaded in the docs
 - Prepend `"test.bib"` with `@__DIR__`
 - Adds a docs environment