### PR TITLE
Add plugin type `CitationBibliography`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,17 @@
-using Documenter
 using DocumenterCitations
+const root_dir = dirname(dirname(pathof(DocumenterCitations)))
+const doc_dir = joinpath(root_dir, "docs")
 import DocumenterCitations
+
+using Documenter
 using Bibliography
 
-DocumenterCitations.BIBLIOGRAPHY() = import_bibtex(joinpath(@__DIR__, "test.bib"))
+cite_bib = CitationBibliography(joinpath(doc_dir, "test.bib"))
 
 makedocs(
+    cite_bib,
     sitename = "Testing BibTeX citations and references",
+    strict = true,
       format = Documenter.HTML(
           prettyurls = get(ENV, "CI", nothing) == "true"
       ),

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -1,7 +1,28 @@
 module DocumenterCitations
 
+using Documenter
+using Documenter.Anchors
+using Documenter.Builder
+using Documenter.Documents
+using Documenter.Selectors
+using Documenter.Utilities
+using Documenter.Expanders
 
-BIBLIOGRAPHY() = ""
+using Markdown
+using Bibliography
+using Bibliography: xnames, xyear, xlink, xtitle, xin
+
+export CitationBibliography
+struct CitationBibliography <: Documenter.Plugin
+    bib::Dict
+end
+function CitationBibliography(filename::AbstractString="")
+    filename == "" && return CitationBibliography(Dict())
+    bf = import_bibtex(filename)
+    return CitationBibliography(bf)
+end
+
+
 include("citations.jl")
 include("bibliography.jl")
 

--- a/src/bibliography.jl
+++ b/src/bibliography.jl
@@ -1,10 +1,3 @@
-using Documenter
-using Documenter.Anchors
-using Documenter.Documents
-using Documenter.Expanders
-using Documenter.Selectors
-
-using Bibliography: xnames, xyear, xlink, xtitle, xin
 
 abstract type BibliographyBlock <: Expanders.ExpanderPipeline end
 
@@ -14,7 +7,7 @@ Selectors.matcher(::Type{BibliographyBlock}, node, page, doc) = Expanders.iscode
 function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
     @info "Expanding bibliography."
     raw_bib = "<dl>"
-    for (id, entry) in BIBLIOGRAPHY()
+    for (id, entry) in doc.plugins[CitationBibliography].bib
         @info "Expanding bibliography entry: $id."
 
         # Add anchor that citations can link to from anywhere in the docs.

--- a/src/citations.jl
+++ b/src/citations.jl
@@ -1,15 +1,4 @@
 
-using Documenter
-using Documenter.Anchors
-using Documenter.Builder
-using Documenter.Documents
-using Documenter.Selectors
-using Documenter.Utilities
-
-using Markdown
-using Bibliography
-using Bibliography: xnames, xyear
-
 abstract type Citations <: Builder.DocumentPipeline end
 
 Selectors.order(::Type{Citations}) = 3.1  # After cross-references
@@ -41,8 +30,8 @@ function expand_citation(link::Markdown.Link, meta, page, doc)
         citation_name = link.text[1]
         @info "Expanding citation: $citation_name."
 
-        if haskey(BIBLIOGRAPHY(), citation_name)
-            entry = BIBLIOGRAPHY()[citation_name]
+        if haskey(doc.plugins[CitationBibliography].bib, citation_name)
+            entry = doc.plugins[CitationBibliography].bib[citation_name]
             headers = doc.internal.headers
             if Anchors.exists(headers, entry.id)
                 if Anchors.isunique(headers, entry.id)


### PR DESCRIPTION
This PR
 - adds `struct CitationBibliography  <: Documenter.plugin` to pass into `Documenter.makedocs`. This plugin is then grabed from `doc` in `expand_citation` and `Selectors.runner` rather than the module-global method.
 - Sets `strict = true` in `makedocs`
