### PR TITLE
Properly format en and em dashes in reference titles

### DIFF
--- a/docs/example.bib
+++ b/docs/example.bib
@@ -21,3 +21,13 @@
     url = {https://archive.org/details/PrincipiaMathematicaVolumeI}
 }
 
+@techreport{CK1994,
+  author = {Carpenter, Mark H and Kennedy, Christopher A},
+  title = {Fourth-order $2N$-storage Runge--Kutta schemes},
+  institution = {National Aeronautics and Space Administration},
+  year = {1994},
+  number = {NASA TM-109112},
+  address = {Langley Research Center, Hampton, VA},
+  url={https://ntrs.nasa.gov/api/citations/19940028444/downloads/19940028444.pdf}
+}
+

--- a/src/bibliography.jl
+++ b/src/bibliography.jl
@@ -9,7 +9,10 @@ const tex2unicode_replacements = (
 )
 
 function tex2unicode(s)
-        replace(s, tex2unicode_replacements...)
+    for replacement in tex2unicode_replacements
+        s = replace(s, replacement)
+    end
+    return s
 end
 
 function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
@@ -37,3 +40,4 @@ function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
 
     page.mapping[x] = Documents.RawNode(:html, raw_bib)
 end
+

--- a/src/bibliography.jl
+++ b/src/bibliography.jl
@@ -3,6 +3,18 @@ abstract type BibliographyBlock <: Expanders.ExpanderPipeline end
 Selectors.order(::Type{BibliographyBlock}) = 12.0  # Expand bibliography last
 Selectors.matcher(::Type{BibliographyBlock}, node, page, doc) = Expanders.iscode(node, r"^@bibliography")
 
+const tex2unicode_replacements = (
+    "--"  => "–",
+    "---" => "—"
+)
+
+function tex2unicode(s)
+    for replacement in tex2unicode_replacements
+        s = replace(s, replacement)
+    end
+    return s
+end
+
 function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
     @info "Expanding bibliography."
     raw_bib = "<dl>"
@@ -15,9 +27,8 @@ function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
         authors = xnames(entry)
         year = xyear(entry)
         link = xlink(entry)
-        title = xtitle(entry)
+        title = xtitle(entry) |> tex2unicode
         published_in = xin(entry)
-
 
         entry_text = """<dt>$id</dt>
         <dd>

--- a/src/bibliography.jl
+++ b/src/bibliography.jl
@@ -9,10 +9,7 @@ const tex2unicode_replacements = (
 )
 
 function tex2unicode(s)
-    for replacement in tex2unicode_replacements
-        s = replace(s, replacement)
-    end
-    return s
+        replace(s, tex2unicode_replacements...)
 end
 
 function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
@@ -40,4 +37,3 @@ function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
 
     page.mapping[x] = Documents.RawNode(:html, raw_bib)
 end
-

--- a/src/bibliography.jl
+++ b/src/bibliography.jl
@@ -1,4 +1,3 @@
-
 abstract type BibliographyBlock <: Expanders.ExpanderPipeline end
 
 Selectors.order(::Type{BibliographyBlock}) = 12.0  # Expand bibliography last
@@ -13,9 +12,16 @@ function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
         # Add anchor that citations can link to from anywhere in the docs.
         Anchors.add!(doc.internal.headers, entry, entry.id, page.build)
 
+        authors = xnames(entry)
+        year = xyear(entry)
+        link = xlink(entry)
+        title = xtitle(entry)
+        published_in = xin(entry)
+
+
         entry_text = """<dt>$id</dt>
         <dd>
-          <div id="$id">$(xnames(entry)) ($(xyear(entry))), <a href="$(xlink(entry))">$(xtitle(entry))</a>, $(xin(entry))</a>
+          <div id="$id">$authors ($year), <a href="$link">$title</a>, $published_in</a>
         </dd>"""
         raw_bib *= entry_text
     end


### PR DESCRIPTION
This PR starts adding support for converting common TeX to unicode starting with en and em dashes.

This PR depends on #13.

Resolves #11 (?)