### PR TITLE
Added Compat version for DataStructures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,6 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 Bibliography = "^0.2"
+DataStructures = "0.18"
 Documenter = "v0.25, 0.26, 0.27"
 julia = "^1.4"


### PR DESCRIPTION
Fixes Error on Pkg registry in JuliaRegistries/General.
The version is the same as `Bibliography.jl` is using.