### PR TITLE
Setup continuous integration tests (WIP, DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ github.event_name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.4'  # oldest supported release
+          - '1.6'  # current LTS release
+          - '1.7'  # latest release
+          - 'nightly'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          file: lcov.info

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using DocumenterCitations
+using Documenter
 using Test
 
 
@@ -14,4 +15,9 @@ using Test
         raw"{\o}verline") == "øverline"
     @test DocumenterCitations.tex2unicode(
         raw"\overline") == "\\overline"
+end
+
+@testset "doctest fix" begin
+    # verify https://github.com/ali-ramadhan/DocumenterCitations.jl/issues/55 is fixed
+    doctest(DocumenterCitations; fix=true)
 end


### PR DESCRIPTION
This is mainly to verify that the `doctest(;fix=true)` test fails here but succeeds in PR #56. We'll see how it turns out.